### PR TITLE
Opravy

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,6 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+img, video { width: 100%; }

--- a/night_rider/night_rider.md
+++ b/night_rider/night_rider.md
@@ -17,7 +17,7 @@ Základy zapojování LED. Základní programové konstrukce pro ovládání dig
 ## Program
 [night_rider.ino](night_rider.ino)
 ```c++
-{% include night_rider.ino %}
+{% include_relative night_rider.ino %}
 ```
 ## Možná vylepšení
 

--- a/semafor/semafor.md
+++ b/semafor/semafor.md
@@ -35,7 +35,7 @@ Pokročilejší úloha s využitím LED, samostatně vytvořit semafor. Míru sa
 ## Program
 [semafor.ino](semafor.ino) - kód je napsán osmiletým dítětem, obsahuje různá vylepšení standardního semaforu viz níže
 ``` c++
-{% include semafor.ino %}
+{% include_relative semafor.ino %}
 ```
 ## Možná vylepšení
 * Doplnění klasického auto-semaforu ještě o semafor pro chodce.

--- a/semafor/semafor.md
+++ b/semafor/semafor.md
@@ -17,7 +17,7 @@ Pokročilejší úloha s využitím LED, samostatně vytvořit semafor. Míru sa
 ## Video
 
 <div markdown="0">
-    <video width="1280" height="720" controls>
+    <video controls>
         <source src="semafor.mp4" type="video/mp4">
         Bohužel, váš prohlížeč neumí HTML5 video. <a href="semafor.mp4">Přehrajte si jej jako soubor.</a>
     </video>

--- a/semafor/semafor.md
+++ b/semafor/semafor.md
@@ -15,12 +15,13 @@ Pokročilejší úloha s využitím LED, samostatně vytvořit semafor. Míru sa
 ![](P1360417.JPG)
 
 ## Video
-<video width="1280" height="720" controls>
-<source src="semafor.mp4" type="video/mp4">
-Bohužel, váš prohlížeč neumí HTML5 video.
-</video> 
 
-[Semafor video](semafor.mp4)
+<div markdown="0">
+    <video width="1280" height="720" controls>
+        <source src="semafor.mp4" type="video/mp4">
+        Bohužel, váš prohlížeč neumí HTML5 video. <a href="semafor.mp4">Přehrajte si jej jako soubor.</a>
+    </video>
+</div>
 
 ## Hardware
 * Zelené, žluté, červené LED


### PR DESCRIPTION
### Vložení videa

Opravil jsem video. Použil jsem trik `markdown="0"`, který umí na určitý tag vypnout Markdown:

```html
<div markdown="0">
  ...
</div>
```

### Oprava includes

Zjistil jsem, že Jekyll má problém s includes ze stejné složky. Musí to být z adresáře `_includes`, nebo se musí použít speciální značka na lokální includes. [Dokumentace.](https://jekyllrb.com/docs/includes/)

### Vzhled videa a obrázků

Video mi přetékalo obrazovku doprava. Taky jsem si všiml, že i většina obrázků přetéká svůj vymezený prostor, i když ne o tolik. Našel jsem, jak lze vestavěný theme rozšířit o svoje CSS. Našel jsem [toto](https://help.github.com/articles/customizing-css-and-html-in-your-jekyll-theme/). Je to nějaká totální magie, ale když jsem to udělal, přidalo se mi moje CSS a mohl jsem doladit šířku obrázků i videa.